### PR TITLE
Revert "Change build.sh to use profiles instead of exporting LIFTWIZARD_FILE_MATCH_RULE_RERECORD directly."

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -122,10 +122,12 @@ if [[ $COMMIT_MESSAGE == *\[no-daemon\]* ]]; then
     MAVEN='./mvnw'
 fi
 
-PROFILES="dev"
+PROFILES='dev'
 if [ "$RECORD" = true ] || [[ $COMMIT_MESSAGE == *\[record\]* ]]; then
-  PROFILES="$PROFILES,rerecord"
+    LIFTWIZARD_RERECORD=true
+    PROFILES="$PROFILES,rerecord"
 fi
+export LIFTWIZARD_FILE_MATCH_RULE_RERECORD=${LIFTWIZARD_RERECORD}
 
 if [[ $COMMIT_MESSAGE == *\[serial\]* ]]; then
     SERIAL=true


### PR DESCRIPTION
This reverts commit 5d6543084f7b322e7cd767ae000b815bb8bae7d0.