### PR TITLE
Improve configuration of maven plugins in the build.

### DIFF
--- a/klass-bom/pom.xml
+++ b/klass-bom/pom.xml
@@ -36,25 +36,6 @@
             <plugins>
 
                 <plugin>
-                    <groupId>org.antlr</groupId>
-                    <artifactId>antlr4-maven-plugin</artifactId>
-                    <version>4.9.3</version>
-                    <executions>
-                        <execution>
-                            <id>antlr</id>
-                            <goals>
-                                <goal>antlr4</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <listener>true</listener>
-                        <visitor>true</visitor>
-                        <treatWarningsAsErrors>true</treatWarningsAsErrors>
-                    </configuration>
-                </plugin>
-
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-archetype-plugin</artifactId>
                     <version>3.2.1</version>

--- a/klass-generator-plugins/klass-compiler-plugin/pom.xml
+++ b/klass-generator-plugins/klass-compiler-plugin/pom.xml
@@ -68,22 +68,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-compiler</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-dropwizard-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-dropwizard-plugin/pom.xml
@@ -85,22 +85,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-dropwizard</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-dto-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-dto-plugin/pom.xml
@@ -85,22 +85,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-dto</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-graphql-fragment-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-graphql-fragment-plugin/pom.xml
@@ -90,22 +90,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-graphql-fragment</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-graphql-reladomo-finder-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-graphql-reladomo-finder-plugin/pom.xml
@@ -90,22 +90,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-graphql-reladomo-finder</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-graphql-schema-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-graphql-schema-plugin/pom.xml
@@ -90,22 +90,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-graphql-schema</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-graphql-schema-query-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-graphql-schema-query-plugin/pom.xml
@@ -90,22 +90,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-graphql-schema-query</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-json-view-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-json-view-plugin/pom.xml
@@ -85,22 +85,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-json-view</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-klass-html-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-klass-html-plugin/pom.xml
@@ -74,22 +74,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-klass-html</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-klass-projection-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-klass-projection-plugin/pom.xml
@@ -80,22 +80,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-klass-projection</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-klass-service-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-klass-service-plugin/pom.xml
@@ -80,22 +80,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-klass-service</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-liquibase-schema-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-liquibase-schema-plugin/pom.xml
@@ -91,22 +91,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-liquibase-schema</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-meta-constants-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-meta-constants-plugin/pom.xml
@@ -85,22 +85,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-meta-constants</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-react-prop-type-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-react-prop-type-plugin/pom.xml
@@ -90,22 +90,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-react-prop-type</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-reladomo-concrete-class-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-reladomo-concrete-class-plugin/pom.xml
@@ -80,22 +80,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-reladomo-concrete-class</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-reladomo-merge-hooks-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-reladomo-merge-hooks-plugin/pom.xml
@@ -85,22 +85,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-reladomo-merge-hooks</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-reladomo-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-reladomo-plugin/pom.xml
@@ -90,22 +90,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-reladomo</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-reladomo-readable-interface-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-reladomo-readable-interface-plugin/pom.xml
@@ -85,22 +85,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-reladomo-readable-interface</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-relational-schema-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-relational-schema-plugin/pom.xml
@@ -91,22 +91,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-relational-schema</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-service-resources-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-service-resources-plugin/pom.xml
@@ -85,22 +85,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-service-resources</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-generator-plugins/klass-generator-uml-nomnoml-plugin/pom.xml
+++ b/klass-generator-plugins/klass-generator-uml-nomnoml-plugin/pom.xml
@@ -90,22 +90,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <goalPrefix>klass-generator-uml-nomnoml</goalPrefix>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/klass-maven-parent/pom.xml
+++ b/klass-maven-parent/pom.xml
@@ -90,7 +90,7 @@
     </dependencyManagement>
 
     <build>
-        <defaultGoal>clean verify</defaultGoal>
+        <defaultGoal>verify</defaultGoal>
 
         <plugins>
 

--- a/klass-model-converters/klass-grammar/pom.xml
+++ b/klass-model-converters/klass-grammar/pom.xml
@@ -46,6 +46,20 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
+                <version>4.9.3</version>
+                <executions>
+                    <execution>
+                        <id>antlr</id>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <listener>true</listener>
+                    <visitor>true</visitor>
+                    <treatWarningsAsErrors>true</treatWarningsAsErrors>
+                </configuration>
             </plugin>
 
         </plugins>

--- a/klass-models/klass-model-bootstrapped/klass-model-bootstrapped-dropwizard-application-tests/pom.xml
+++ b/klass-models/klass-model-bootstrapped/klass-model-bootstrapped-dropwizard-application-tests/pom.xml
@@ -43,18 +43,6 @@
                 <directory>src/test/inputresources</directory>
             </testResource>
         </testResources>
-
-        <plugins>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.4.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <skipPublishing>true</skipPublishing>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 
     <dependencies>

--- a/klass-models/klass-model-bootstrapped/klass-model-bootstrapped-dropwizard-application/pom.xml
+++ b/klass-models/klass-model-bootstrapped/klass-model-bootstrapped-dropwizard-application/pom.xml
@@ -103,16 +103,6 @@
                 </dependencies>
             </plugin>
 
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.4.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <skipPublishing>true</skipPublishing>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 

--- a/klass-models/klass-model-bootstrapped/pom.xml
+++ b/klass-models/klass-model-bootstrapped/pom.xml
@@ -44,7 +44,7 @@
     <name>${app.name} (Module Group)</name>
 
     <build>
-        <defaultGoal>clean verify</defaultGoal>
+        <defaultGoal>verify</defaultGoal>
 
         <plugins>
 

--- a/klass-test-modules/pom.xml
+++ b/klass-test-modules/pom.xml
@@ -35,20 +35,6 @@
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.4.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <skipPublishing>true</skipPublishing>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <modules>
         <module>klass-tests</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     </dependencyManagement>
 
     <build>
-        <defaultGoal>clean verify</defaultGoal>
+        <defaultGoal>verify</defaultGoal>
 
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -151,25 +151,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.antlr</groupId>
-                    <artifactId>antlr4-maven-plugin</artifactId>
-                    <version>4.9.3</version>
-                    <executions>
-                        <execution>
-                            <id>antlr</id>
-                            <goals>
-                                <goal>antlr4</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <listener>true</listener>
-                        <visitor>true</visitor>
-                        <treatWarningsAsErrors>true</treatWarningsAsErrors>
-                    </configuration>
-                </plugin>
-
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-archetype-plugin</artifactId>
                     <version>3.2.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,28 @@
                     </configuration>
                 </plugin>
 
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <configuration>
+                        <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>mojo-descriptor</id>
+                            <goals>
+                                <goal>descriptor</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>help-goal</id>
+                            <goals>
+                                <goal>helpmojo</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
             </plugins>
         </pluginManagement>
 

--- a/xample-projects/coverage-example/pom.xml
+++ b/xample-projects/coverage-example/pom.xml
@@ -91,7 +91,7 @@
     </dependencyManagement>
 
     <build>
-        <defaultGoal>clean verify</defaultGoal>
+        <defaultGoal>verify</defaultGoal>
 
         <plugins>
 

--- a/xample-projects/pom.xml
+++ b/xample-projects/pom.xml
@@ -42,20 +42,6 @@
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.4.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <skipPublishing>true</skipPublishing>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencyManagement>
         <dependencies>
 

--- a/xample-projects/reladomo-abstract-implements-interface/pom.xml
+++ b/xample-projects/reladomo-abstract-implements-interface/pom.xml
@@ -69,7 +69,7 @@
     </dependencyManagement>
 
     <build>
-        <defaultGoal>clean verify</defaultGoal>
+        <defaultGoal>verify</defaultGoal>
 
         <plugins>
 

--- a/xample-projects/reladomo-abstract-owned-foreign-key/pom.xml
+++ b/xample-projects/reladomo-abstract-owned-foreign-key/pom.xml
@@ -69,7 +69,7 @@
     </dependencyManagement>
 
     <build>
-        <defaultGoal>clean verify</defaultGoal>
+        <defaultGoal>verify</defaultGoal>
 
         <plugins>
 

--- a/xample-projects/reladomo-to-many-abstract/pom.xml
+++ b/xample-projects/reladomo-to-many-abstract/pom.xml
@@ -63,7 +63,7 @@
         </dependencies>
     </dependencyManagement>
     <build>
-        <defaultGoal>clean verify</defaultGoal>
+        <defaultGoal>verify</defaultGoal>
         <plugins>
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/xample-projects/stackoverflow/pom.xml
+++ b/xample-projects/stackoverflow/pom.xml
@@ -84,7 +84,7 @@
     </dependencyManagement>
 
     <build>
-        <defaultGoal>clean verify</defaultGoal>
+        <defaultGoal>verify</defaultGoal>
 
         <plugins>
 


### PR DESCRIPTION
- Delete redundant configuration of central-publishing-maven-plugin.
- Change the default maven goal from `clean verify` to just `verify`.
- Pull up the configuration of maven-plugin-plugin.
- Consolidate configuration of antlr4-maven-plugin.
